### PR TITLE
Replace calls to django.conf.urls.url with django.urls.path or re_path

### DIFF
--- a/instance_selector/urls.py
+++ b/instance_selector/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import url
+from django.urls import re_path
 from instance_selector.views import instance_selector_embed, instance_selector_lookup
 
 
 urlpatterns = [
-    url(
+    re_path(
         r"^instance-selector/embed/(?P<app_label>[\w-]+).(?P<model_name>[\w-]+)/$",
         instance_selector_embed,
         name="wagtail_instance_selector_embed",
     ),
-    url(
+    re_path(
         r"^instance-selector/lookup/(?P<app_label>[\w-]+).(?P<model_name>[\w-]+)/$",
         instance_selector_lookup,
         name="wagtail_instance_selector_lookup",

--- a/tests/test_project/urls.py
+++ b/tests/test_project/urls.py
@@ -1,10 +1,11 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.core import urls as wagtail_urls
 
+# from wagtail.documents import urls as wagtaildocs_urls
+
 urlpatterns = [
-    url(r"^admin/", include(wagtailadmin_urls)),
-    # url(r'^documents/', include(wagtaildocs_urls)),
-    url(r"", include(wagtail_urls)),
+    path("admin/", include(wagtailadmin_urls)),
+    # path('documents/', include(wagtaildocs_urls)),
+    path("", include(wagtail_urls)),
 ]


### PR DESCRIPTION
`django.urls.path` and `re_path` methods have been added in Django 2.0 and `django.conf.urls.url` method is deprecated since the 3.1 release.