### PR TITLE
Moves `get_user_model` into `get_instance_selector`; Fixes #12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+### 2.0.1 (01/05/2021)
+
+- Fix for custom user model compatibility.
+  PR: https://github.com/ixc/wagtail-instance-selector/pull/13.
+
 ### 2.0.0 (24/08/2020)
 
 - Django 3 compatibility: replaced calls to django.conf.urls.url with django.urls.path or re_path. 

--- a/instance_selector/__init__.py
+++ b/instance_selector/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 default_app_config = "%s.apps.AppConfig" % __name__

--- a/instance_selector/registry.py
+++ b/instance_selector/registry.py
@@ -12,8 +12,6 @@ from instance_selector.exceptions import ModelAdminLookupFailed
 __all__ = ("Registry", "registry")
 
 
-User = get_user_model()
-
 
 class Registry:
     def __init__(self):
@@ -32,6 +30,7 @@ class Registry:
         return self._models[key]
 
     def get_instance_selector(self, model):
+        User = get_user_model()
         if model not in self._selectors:
             from wagtail.admin.menu import admin_menu, settings_menu
 


### PR DESCRIPTION
The explanation for this is in #12. 