### PR TITLE
Wagtail 2.13 compatibility

### DIFF
--- a/instance_selector/blocks.py
+++ b/instance_selector/blocks.py
@@ -5,6 +5,18 @@ from instance_selector.widgets import InstanceSelectorWidget
 from instance_selector.registry import registry
 
 
+try:
+    from wagtail.core.telepath import register
+    from wagtail.core.blocks.field_block import FieldBlockAdapter
+except ImportError:  # do-nothing fallback for Wagtail <2.13
+
+    def register(adapter, cls):
+        pass
+
+    class FieldBlockAdapter:
+        pass
+
+
 class InstanceSelectorBlock(ChooserBlock):
     class Meta:
         icon = "placeholder"
@@ -39,3 +51,18 @@ class InstanceSelectorBlock(ChooserBlock):
 
         kwargs["target_model"] = self.target_model._meta.label_lower
         return name, args, kwargs
+
+
+class InstanceSelectorBlockAdapter(FieldBlockAdapter):
+    def js_args(self, block):
+        name, widget, meta = super().js_args(block)
+
+        # Fix up the 'icon' item in meta so that it's a string that we can serialize,
+        # rather than a lazy reference
+        if callable(meta["icon"]):
+            meta["icon"] = meta["icon"]()
+
+        return [name, widget, meta]
+
+
+register(InstanceSelectorBlockAdapter(), InstanceSelectorBlock)

--- a/instance_selector/blocks.py
+++ b/instance_selector/blocks.py
@@ -39,6 +39,9 @@ class InstanceSelectorBlock(ChooserBlock):
     def widget(self):
         return InstanceSelectorWidget(self.target_model)
 
+    def get_form_state(self, value):
+        return self.widget.get_value_data(value)
+
     def get_instance_selector_icon(self):
         instance_selector = registry.get_instance_selector(self.target_model)
         return instance_selector.get_widget_icon()

--- a/instance_selector/static/instance_selector/instance_selector_telepath.js
+++ b/instance_selector/static/instance_selector/instance_selector_telepath.js
@@ -1,0 +1,21 @@
+(function() {
+    function InstanceSelector(html, config) {
+        this.html = html;
+        this.baseConfig = config;
+    }
+    InstanceSelector.prototype.render = function(placeholder, name, id, initialState) {
+        var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
+        placeholder.outerHTML = html;
+        var config = {};
+        // replace __NAME__ and __ID__ placeholders in config with the real name / id
+        for (prop in this.baseConfig) {
+            config[prop] = this.baseConfig[prop].replace(/__NAME__/g, name).replace(/__ID__/g, id);;
+        }
+
+        var chooser = create_instance_selector_widget(config);
+        chooser.setState(initialState);
+        return chooser;
+    };
+
+    window.telepath.register('wagtailinstanceselector.widgets.InstanceSelector', InstanceSelector);
+})();

--- a/instance_selector/static/instance_selector/instance_selector_widget.js
+++ b/instance_selector/static/instance_selector/instance_selector_widget.js
@@ -115,4 +115,27 @@ function create_instance_selector_widget(opts) {
                 .removeClass('instance-selector-widget--selected');
         }
     }
+
+    // define public API functions for the widget:
+    // https://docs.wagtail.io/en/latest/reference/streamfield/widget_api.html
+    const widget_api = {
+        idForLabel: null,
+        getState: function() {
+            return {
+                'pk': field_input.val(),
+                'display_markup': display_markup_wrap.html(),
+                'edit_url': edit_button.attr('href'),
+            };
+        },
+        getValue: function() {
+            return field_input.val();
+        },
+        setState: function(newState) {
+            set_value(newState);
+        },
+        focus: function() {
+            trigger_button.focus();
+        },
+    }
+    return widget_api;
 }

--- a/instance_selector/templates/instance_selector/instance_selector_widget.html
+++ b/instance_selector/templates/instance_selector/instance_selector_widget.html
@@ -31,15 +31,3 @@
 </div>
 
 {{ original_field_html }}
-
-<script>
-    create_instance_selector_widget({
-        input_id: '{{ input_id }}',
-        widget_id: '{{ widget_id }}',
-        field_name: '{{ name }}',
-        embed_url: '{{ embed_url }}',
-        embed_id: '{{ embed_id }}',
-        lookup_url: '{{ lookup_url }}',
-        OBJECT_PK_PARAM: '{{ OBJECT_PK_PARAM }}'
-    });
-</script>

--- a/instance_selector/templates/instance_selector/instance_selector_widget.html
+++ b/instance_selector/templates/instance_selector/instance_selector_widget.html
@@ -1,6 +1,6 @@
 <div
     id="{{ widget_id }}"
-    class="instance-selector-widget {% if value %}instance-selector-widget--selected{% else %}instance-selector-widget--unselected{% endif %} {% if widget.is_required %}instance-selector-widget--required{% else %}instance-selector-widget--not-required{% endif %}"
+    class="instance-selector-widget {% if is_nonempty %}instance-selector-widget--selected{% else %}instance-selector-widget--unselected{% endif %} {% if widget.is_required %}instance-selector-widget--required{% else %}instance-selector-widget--not-required{% endif %}"
 >
     <div class="instance-selector-widget__display-wrap js-instance-selector-widget-display-wrap">
         {{ display_markup }}

--- a/instance_selector/widgets.py
+++ b/instance_selector/widgets.py
@@ -1,6 +1,7 @@
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.widgets import AdminChooser
 from instance_selector.constants import OBJECT_PK_PARAM
 from instance_selector.registry import registry
@@ -17,15 +18,44 @@ class InstanceSelectorWidget(AdminChooser):
 
         super().__init__(**kwargs)
 
-    def render_html(self, name, value, attrs):
-        original_field_html = super().render_html(name, value, attrs)
+    def get_value_data(self, value):
+        # Given a data value (which may be None, a model instance, or a PK here),
+        # extract the necessary data for rendering the widget with that value.
+        # In the case of StreamField (in Wagtail >=2.13), this data will be serialised via
+        # telepath https://wagtail.github.io/telepath/ to be rendered client-side, which means it
+        # cannot include model instances. Instead, we return the raw values used in rendering -
+        # namely: pk, display_markup and edit_url
 
-        instance, value = self.get_instance_and_id(self.target_model, value)
+        if value is None or isinstance(value, self.target_model):
+            instance = value
+        else:  # assume this is an instance ID
+            instance = self.target_model.objects.get(pk=value)
 
         app_label = self.target_model._meta.app_label
         model_name = self.target_model._meta.model_name
         model = registry.get_model(app_label, model_name)
         instance_selector = registry.get_instance_selector(model)
+        display_markup = instance_selector.get_instance_display_markup(instance)
+        edit_url = instance_selector.get_instance_edit_url(instance)
+
+        return {
+            "pk": instance.pk if instance else None,
+            "display_markup": display_markup,
+            "edit_url": edit_url,
+        }
+
+    def render_html(self, name, value, attrs):
+        if WAGTAIL_VERSION >= (2, 13):
+            # From Wagtail 2.13, get_value_data is called as a preprocessing step in
+            # WidgetWithScript before invoking render_html
+            value_data = value
+        else:
+            value_data = self.get_value_data(value)
+
+        original_field_html = super().render_html(name, value_data["pk"], attrs)
+
+        app_label = self.target_model._meta.app_label
+        model_name = self.target_model._meta.model_name
 
         embed_url = reverse(
             "wagtail_instance_selector_embed",
@@ -41,14 +71,11 @@ class InstanceSelectorWidget(AdminChooser):
             kwargs={"app_label": app_label, "model_name": model_name},
         )
 
-        display_markup = instance_selector.get_instance_display_markup(instance)
-        edit_url = instance_selector.get_instance_edit_url(instance)
-
         return render_to_string(
             "instance_selector/instance_selector_widget.html",
             {
                 "name": name,
-                "value": value,
+                "is_nonempty": value_data["pk"] is not None,
                 "widget": self,
                 "input_id": attrs["id"],
                 "widget_id": "%s-instance-selector-widget" % attrs["id"],
@@ -57,7 +84,7 @@ class InstanceSelectorWidget(AdminChooser):
                 "embed_id": embed_id,
                 "lookup_url": lookup_url,
                 "OBJECT_PK_PARAM": OBJECT_PK_PARAM,
-                "display_markup": display_markup,
-                "edit_url": edit_url,
+                "display_markup": value_data["display_markup"],
+                "edit_url": value_data["edit_url"],
             },
         )

--- a/tests/test_instance_selector.py
+++ b/tests/test_instance_selector.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 from django_webtest import WebTest
 from django.contrib.auth import get_user_model
+from wagtail import VERSION as WAGTAIL_VERSION
 
 from instance_selector.constants import OBJECT_PK_PARAM
 from instance_selector.registry import registry
@@ -231,7 +232,15 @@ class Tests(WebTest):
         res = self.app.get(
             "/admin/test_app/testmodelc/edit/%s/" % c.pk, user=self.superuser
         )
-        self.assertIn(
-            'class="instance-selector-widget instance-selector-widget--unselected instance-selector-widget--required"',
-            res.text,
-        )
+        if WAGTAIL_VERSION < (2, 13):
+            # widget is directly rendered on the page
+            self.assertIn(
+                'class="instance-selector-widget instance-selector-widget--unselected instance-selector-widget--required"',
+                res.text,
+            )
+        else:
+            # rendered widget output is embedded in JSON within the data-block attribute
+            self.assertIn(
+                "class=\&quot;instance-selector-widget instance-selector-widget--unselected instance-selector-widget--required\&quot;",
+                res.text,
+            )


### PR DESCRIPTION
Fixes #11. The new telepath StreamField implementation in 2.13 requires some fairly heavy refactoring to the InstanceSelector widget, since InstanceSelector was quite heavily reliant on rendering a template for each instance, while StreamField needs to be able to construct them client-side from serialised data. I got it working by extracting an 'state' dict consisting of the pk, display_markup and edit_url, which can be used by both the server-side and client-side rendering logic.

(For reference, I submitted a fairly similar patch to wagtailmodelchooser that might help in following the changes: https://github.com/neon-jungle/wagtailmodelchooser/pull/27)