### PR TITLE
Define default_app_config for Django < 3.2 only

### DIFF
--- a/instance_selector/__init__.py
+++ b/instance_selector/__init__.py
@@ -1,3 +1,7 @@
+import django
+
+
 __version__ = "2.1.1"
 
-default_app_config = "%s.apps.AppConfig" % __name__
+if django.VERSION < (3, 2):
+    default_app_config = "%s.apps.AppConfig" % __name__


### PR DESCRIPTION
Since Django 3.2 it is not necessary anymore to declare a `default_app_config` is only a single app config is present in the `apps.py`.

With that declaration, Django throws deprecation warnings like so:
```
/venv/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'instance_selector' defines default_app_config = 'instance_selector.apps.AppConfig'. Django now detects this configuration automatically. You can remove default_app_config.
```

This PR adds a conditional check to only define the `default_app_config` if a Django version lower than 3.2 is used.

Closes #23