### PR TITLE
Django 4.0 compatibility

### DIFF
--- a/instance_selector/widgets.py
+++ b/instance_selector/widgets.py
@@ -1,7 +1,7 @@
 import json
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.widgets import AdminChooser
 from instance_selector.constants import OBJECT_PK_PARAM

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=2.2.2,<4.0
+django>=2.2.2,<5.0
 django-webtest>=1.9.5,<2.0
 wagtail>=2.5.1,<3.0
 black==19.10b0


### PR DESCRIPTION
**ugettext_lazy** [has been removed in Django 4.0 159](https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0). Please use **gettext_lazy** instead:

`from django.utils.translation import gettext_lazy as _`